### PR TITLE
Nicer handling of the command not being found

### DIFF
--- a/aws-lib
+++ b/aws-lib
@@ -5,7 +5,7 @@ logInfo() {
 }
 
 requireCommand() {
-    if ! hash "$1"; then
+    if ! hash "$1" 2> /dev/null; then
         echo "Missing command: $1" >&2
         exit 2
     fi


### PR DESCRIPTION
The call to hash caused unsightly errors to be printed to my screen, followed by by the error msg you print. This hides the hash created errors.
