### PR TITLE
Used this helper fn. to catch a missing aws cli

### DIFF
--- a/update-cloud-formation
+++ b/update-cloud-formation
@@ -6,6 +6,8 @@ cd "${0%/*}"
 
 template="$(pwd)/cloudformation.json"
 
+requireCommand aws
+
 if [[ -e "$template" ]]; then
     logInfo "Removing a previous template"
     rm "$template"


### PR DESCRIPTION
This uses the `requireCommand` helper function to check for the existence of the `aws` cli.
